### PR TITLE
Better 5.27 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(EMAIL "mvourlakos@gmail.com")
 
 set(QT_MIN_VERSION "5.15.0")
 set(KF5_MIN_VERSION "5.81.0")
-set(KDECORATION2_MIN_VERSION "5.26.90")
+set(KDECORATION2_MIN_VERSION "5.24.0")
 
 set(KF5_LOCALE_PREFIX "")
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if ! [ -a build ] ; then
+    mkdir build
+fi
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -Wnodev ..
+make -j$(nproc)

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,4 @@
-if ! [ -a build ] ; then
-    mkdir build
-fi
+#!/bin/sh
+./build.sh
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -Wnodev ..
-make -j$(nproc)
 sudo make install

--- a/libappletdecoration/previewclient.h
+++ b/libappletdecoration/previewclient.h
@@ -74,7 +74,11 @@ public:
     QString caption() const override;
     WId decorationId() const override;
     WId windowId() const override;
+#if KDECORATION2_VERSION_MINOR <= 24
+    QString windowClass() const;
+#else
     QString windowClass() const override;
+#endif
     int desktop() const override;
     QIcon icon() const override;
     bool isActive() const override;


### PR DESCRIPTION
Apply the sugested change to make it backwards compatible with KDecoration 5.24 (and Kubuntu 22.04 LTS ) : https://github.com/psifidotos/applet-window-buttons/pull/191/files#r1155487331

Also, improved build scripts